### PR TITLE
Adds the beginning stages of hero transitions.

### DIFF
--- a/client/router.js
+++ b/client/router.js
@@ -27,6 +27,7 @@ Router.route('/', function() {
   $('ul.tabs').tabs();
 }, {
   onAfterAction: function(){
+    // trigger looking for matching super-ids in the html
     Meteor.transitioner.heroAnimations();
   }
 });
@@ -40,6 +41,7 @@ Router.route('/contact/:_id', {
   },
   onAfterAction: function() {
     Session.set('pageTitle', 'Contacts');
+    // trigger looking for matching super-ids in the html
     Meteor.transitioner.heroAnimations();
   }
 });

--- a/client/router.js
+++ b/client/router.js
@@ -4,6 +4,7 @@ Router.configure({
   loadingTemplate: 'loadingLayout'
 });
 
+
 Router.route('/', function() {
   this.render('contacts', {
     data: {
@@ -19,12 +20,15 @@ Router.route('/', function() {
           sort: { last_name: 1 }
         });
       }
-    }
+    },
   });
   Session.set('pageTitle', 'Contact');
-
   // TODO: Load this in the proper place...
   $('ul.tabs').tabs();
+}, {
+  onAfterAction: function(){
+    Meteor.transitioner.heroAnimations();
+  }
 });
 
 Router.route('/contact/:_id', {
@@ -36,10 +40,8 @@ Router.route('/contact/:_id', {
   },
   onAfterAction: function() {
     Session.set('pageTitle', 'Contacts');
+    Meteor.transitioner.heroAnimations();
   }
 });
 
-Transitioner.default({
-  in: 'transition.slideRightBigIn',
-  out: 'transition.slideRightBigOut'
-});
+

--- a/client/transitions.js
+++ b/client/transitions.js
@@ -1,0 +1,106 @@
+Meteor.transitioner = (function(){
+  var Interface = {};
+  var registeredAnimations = [];
+  var self = Interface;
+  Interface.animated = false;
+  Interface.slideListIn = function(){
+    if($('.collection-item').length === 0 && !Interface.animated){
+      setTimeout(function(){Interface.slideListIn()}, 100);
+    }
+    else if(!Interface.animated){
+      Interface.animated = true;
+      $('.collection-item').velocity('transition.perspectiveLeftIn', {stagger: 55, duration: 1000});
+      $('.tab').velocity('transition.slideUpIn', {stagger: 55, duration: 1000});
+      setTimeout(function(){Interface.animated = false}, 2000);
+    }
+  }
+  Interface.heroAnimations = function(){
+    console.log('called hero');
+    var allHeros = $("[super-hero='true']");
+    var interval = setInterval(function(){
+      allHeros.each(function(){
+      var target = $('[super-id=\'' + $(this).attr('super-id') + '\']');
+        if(target.length > 1){
+          if(!self.isRegistered('hero')){
+            self.registerAnimation('hero');
+            self.animateHero(target);
+            console.log('match-found');
+          }
+          clearInterval(interval);
+        }
+      });
+    }, 100);
+  }
+  Interface.animateHero = function(targets){
+    var that = this;
+    var classes = [];
+    var index = 0;
+    var animationTarget;
+    var finalObject;
+    var startState;
+    var endState;
+    targets.each(function(){
+      if(index === 0){
+         animationTarget = $(this);
+         startState = {
+           left: $(this).offset().left,
+           top: $(this).offset().top,
+           width: $(this).width(),
+           height: $(this).height()};
+        }
+      if(index === 1){
+        finalObject = $(this);
+        finalObject.css('visibility', 'hidden');
+        endState = {
+          left: $(this).offset().left,
+          top: $(this).offset().top,
+          width: $(this).width(),
+          height: $(this).height()}
+
+      }
+      $('body').append(animationTarget);
+      animationTarget.addClass('.removeMe');
+      animationTarget.css({top: startState.top, left: startState.left, width: startState.width, height: startState.height, position: 'absolute'});
+      index++;
+    });
+    animationTarget.animate({
+          top: endState.top,
+          left: endState.left,
+          width: endState.width,
+          height: endState.height
+        }, 1000, function(){
+          animationTarget.remove();
+          finalObject.css('visibility', 'visible');
+        });
+    startState = {};
+    endState = {};
+    setTimeout(function(){
+      self.unRegisterAnimation('hero');
+    }, 1000);
+  }
+  Interface.isRegistered = function(animation){
+    if(registeredAnimations.indexOf(animation) > -1){
+      return true;
+    }
+    else{
+      return false;
+    }
+  }
+  Interface.registerAnimation = function(animation){
+    if(!this.isRegistered(animation)){
+      registeredAnimations[registeredAnimations.length] = animation;
+    }
+  }
+  Interface.unRegisterAnimation = function(animation){
+    if(self.isRegistered(animation)){
+      registeredAnimations.splice(registeredAnimations.indexOf(animation), 1);
+    }
+  }
+  return Interface;
+})();
+
+Transitioner.default({
+  in: 'transition.fadeIn',
+  out: 'transition.fadeOut'
+})
+

--- a/client/transitions.js
+++ b/client/transitions.js
@@ -1,21 +1,13 @@
+// Use only one namespace for the entire functionality of transitions
+
 Meteor.transitioner = (function(){
   var Interface = {};
   var registeredAnimations = [];
   var self = Interface;
+  // boolean to hack around iron router being called twice during transitions
   Interface.animated = false;
-  Interface.slideListIn = function(){
-    if($('.collection-item').length === 0 && !Interface.animated){
-      setTimeout(function(){Interface.slideListIn()}, 100);
-    }
-    else if(!Interface.animated){
-      Interface.animated = true;
-      $('.collection-item').velocity('transition.perspectiveLeftIn', {stagger: 55, duration: 1000});
-      $('.tab').velocity('transition.slideUpIn', {stagger: 55, duration: 1000});
-      setTimeout(function(){Interface.animated = false}, 2000);
-    }
-  }
+
   Interface.heroAnimations = function(){
-    console.log('called hero');
     var allHeros = $("[super-id]");
     var found = false;
     var interval = setInterval(function(){
@@ -25,7 +17,6 @@ Meteor.transitioner = (function(){
           if(!self.isRegistered('hero' + $(this).attr('super-id'))){
             self.registerAnimation('hero' + $(this).attr('super-id'));
             self.animateHero(target);
-            console.log('match-found');
           }
           found = true;
         }
@@ -51,33 +42,37 @@ Meteor.transitioner = (function(){
            top: $(this).offset().top,
            width: $(this).width(),
            height: $(this).height(),
-           textAlign: $(this).css('text-align')};
+           textAlign: $(this).css('text-align'),
+           borderRadius: $(this).css('borderRadius')};
         }
       if(index === 1){
         finalObject = $(this);
         finalObject.css('visibility', 'hidden');
-        console.log($(this).parent().parent().parent().scrollTop());
         endState = {
           left: $(this).offset().left,
           top: $(this).offset().top + $(this).parent().parent().parent().scrollTop(),
           width: $(this).width(),
           height: $(this).height(),
-          textAlign: $(this).css('text-align')}
+          textAlign: $(this).css('text-align'),
+          borderRadius: $(this).css('borderRadius')};
       }
       $('body').append(animationTarget);
       animationTarget.addClass('.removeMe');
-      animationTarget.css({top: startState.top, left: startState.left, width: startState.width, height: startState.height, position: 'absolute'});
+      animationTarget.css({top: startState.top, left: startState.left, width: startState.width, height: startState.height, borderRadius: startState.borderRadius, position: 'absolute'});
       index++;
     });
     if(finalObject.css('textAlign') === 'center'){
       animationTarget.css('textAlign', endState.textAlign);
     }
-    console.log('startStateTop', startState.top, 'endStateTop', endState.top);
-    animationTarget.animate({
+    else if(startState.textAlign === 'center'){
+      animationTarget.css('textAlign', 'center');
+    }
+    animationTarget.velocity({
           top: endState.top,
           left: endState.left,
           width: endState.width,
           height: endState.height,
+          borderRadius: endState.borderRadius
         }, {
           complete: function(){
             animationTarget.remove();

--- a/client/transitions.js
+++ b/client/transitions.js
@@ -56,9 +56,10 @@ Meteor.transitioner = (function(){
       if(index === 1){
         finalObject = $(this);
         finalObject.css('visibility', 'hidden');
+        console.log($(this).parent().parent().parent().scrollTop());
         endState = {
           left: $(this).offset().left,
-          top: $(this).offset().top,
+          top: $(this).offset().top + $(this).parent().parent().parent().scrollTop(),
           width: $(this).width(),
           height: $(this).height(),
           textAlign: $(this).css('text-align')}
@@ -68,15 +69,23 @@ Meteor.transitioner = (function(){
       animationTarget.css({top: startState.top, left: startState.left, width: startState.width, height: startState.height, position: 'absolute'});
       index++;
     });
-    animationTarget.css('textAlign', endState.textAlign);
+    if(finalObject.css('textAlign') === 'center'){
+      animationTarget.css('textAlign', endState.textAlign);
+    }
+    console.log('startStateTop', startState.top, 'endStateTop', endState.top);
     animationTarget.animate({
           top: endState.top,
           left: endState.left,
           width: endState.width,
           height: endState.height,
-        }, 1000, function(){
-          animationTarget.remove();
-          finalObject.css('visibility', 'visible');
+        }, {
+          complete: function(){
+            animationTarget.remove();
+            finalObject.css('visibility', 'visible');
+          },
+          duration: 1000,
+          step: function(){
+          }
         });
     startState = {};
     endState = {};

--- a/client/transitions.js
+++ b/client/transitions.js
@@ -16,19 +16,23 @@ Meteor.transitioner = (function(){
   }
   Interface.heroAnimations = function(){
     console.log('called hero');
-    var allHeros = $("[super-hero='true']");
+    var allHeros = $("[super-id]");
+    var found = false;
     var interval = setInterval(function(){
       allHeros.each(function(){
       var target = $('[super-id=\'' + $(this).attr('super-id') + '\']');
         if(target.length > 1){
-          if(!self.isRegistered('hero')){
-            self.registerAnimation('hero');
+          if(!self.isRegistered('hero' + $(this).attr('super-id'))){
+            self.registerAnimation('hero' + $(this).attr('super-id'));
             self.animateHero(target);
             console.log('match-found');
           }
-          clearInterval(interval);
+          found = true;
         }
       });
+      if(found){
+        clearInterval(interval);
+      }
     }, 100);
   }
   Interface.animateHero = function(targets){
@@ -46,7 +50,8 @@ Meteor.transitioner = (function(){
            left: $(this).offset().left,
            top: $(this).offset().top,
            width: $(this).width(),
-           height: $(this).height()};
+           height: $(this).height(),
+           textAlign: $(this).css('text-align')};
         }
       if(index === 1){
         finalObject = $(this);
@@ -55,19 +60,20 @@ Meteor.transitioner = (function(){
           left: $(this).offset().left,
           top: $(this).offset().top,
           width: $(this).width(),
-          height: $(this).height()}
-
+          height: $(this).height(),
+          textAlign: $(this).css('text-align')}
       }
       $('body').append(animationTarget);
       animationTarget.addClass('.removeMe');
       animationTarget.css({top: startState.top, left: startState.left, width: startState.width, height: startState.height, position: 'absolute'});
       index++;
     });
+    animationTarget.css('textAlign', endState.textAlign);
     animationTarget.animate({
           top: endState.top,
           left: endState.left,
           width: endState.width,
-          height: endState.height
+          height: endState.height,
         }, 1000, function(){
           animationTarget.remove();
           finalObject.css('visibility', 'visible');
@@ -75,7 +81,7 @@ Meteor.transitioner = (function(){
     startState = {};
     endState = {};
     setTimeout(function(){
-      self.unRegisterAnimation('hero');
+      self.unRegisterAnimation('hero' + animationTarget.attr('super-id'));
     }, 1000);
   }
   Interface.isRegistered = function(animation){

--- a/meteor-contacts.html
+++ b/meteor-contacts.html
@@ -36,6 +36,9 @@
       <li class="collection-item">
         <a href="{{pathFor route='contact.show'}}">
           <span>
+            <!-- TODO: first_name super-id binding should be changed to something more unique to link transitions
+                 TODO: something like super-id='{{unique identifier to model + type}}'
+                 type being avatar, name, company ect --> 
             <img super-hero='true' super-id="{{first_name}}" src="{{image}}" class="circle profile-pic">
           </span>
           <span class="person-info">
@@ -50,7 +53,7 @@
 
 <template name="contactShow">
   <div  class="contact-header">
-    <img super-hero='true' super-id="{{first_name}}" src="{{image}}" class="circle">
+    <img super-hero='true' super-id="{{first_name}}" src="{{image}}" class="circle radius-test">
     <div super-id="{{first_name}}-name">{{first_name}} {{last_name}}</div>
   <div super-id="{{first_name}}-company">{{company_name}}</div>
   </div>

--- a/meteor-contacts.html
+++ b/meteor-contacts.html
@@ -36,7 +36,7 @@
       <li class="collection-item">
         <a href="{{pathFor route='contact.show'}}">
           <span>
-            <img src="{{image}}" class="circle profile-pic">
+            <img super-hero='true' super-id="{{first_name}}" src="{{image}}" class="circle profile-pic">
           </span>
           <span class="person-info">
             <div class="name">{{first_name}} {{last_name}}</div>
@@ -50,7 +50,7 @@
 
 <template name="contactShow">
   <div  class="contact-header">
-    <img src="{{image}}" class="circle">
+    <img super-hero='true' super-id="{{first_name}}" src="{{image}}" class="circle">
     <div>{{first_name}} {{last_name}}</div>
   <div>{{company_name}}</div>
   </div>

--- a/meteor-contacts.html
+++ b/meteor-contacts.html
@@ -39,8 +39,8 @@
             <img super-hero='true' super-id="{{first_name}}" src="{{image}}" class="circle profile-pic">
           </span>
           <span class="person-info">
-            <div class="name">{{first_name}} {{last_name}}</div>
-            <div class="company">{{company_name}}</div>
+            <div class="name" super-id="{{first_name}}-name">{{first_name}} {{last_name}}</div>
+            <div class="company" super-id="{{first_name}}-company">{{company_name}}</div>
           </span>
         </a>
       </li>
@@ -51,7 +51,7 @@
 <template name="contactShow">
   <div  class="contact-header">
     <img super-hero='true' super-id="{{first_name}}" src="{{image}}" class="circle">
-    <div>{{first_name}} {{last_name}}</div>
-  <div>{{company_name}}</div>
+    <div super-id="{{first_name}}-name">{{first_name}} {{last_name}}</div>
+  <div super-id="{{first_name}}-company">{{company_name}}</div>
   </div>
 </template>

--- a/meteor-contacts.scss
+++ b/meteor-contacts.scss
@@ -67,3 +67,7 @@ footer {
 .transitioner {
   overflow: visible;
 }
+// keeps the face in front ---  TODO: add a super-primary class to always have the highest z-index
+.circle{
+  z-index: 5;
+}

--- a/meteor-contacts.scss
+++ b/meteor-contacts.scss
@@ -10,7 +10,7 @@ body {
   margin:0;
   display: flex;
   flex-direction: column;
-
+  overflow-x: hidden;
 }
 
 header {
@@ -58,7 +58,6 @@ footer {
     }
   }
 }
-
 //Individual Contact
 .contact-header{
   text-align: center;


### PR DESCRIPTION
Only top, left, height, and width supported across all browsers, border-radius works in chrome. 

It catches its two target elements in the transioner phase and injects the starting one into the new page.  From there the base css is applied again but with absolute positioning and then it is animated to the position of the target element.

After the animation is destroyed then the real element is revealed with css visibility: visible.
